### PR TITLE
240221 fix typo index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-loris.github.io
+aces.github.io/MCIN_platforms
 ===============
 
-General LORIS presentation
+Information about MCIN platforms and Projects

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 	      </td>
 	      
 	  </tr></table>
-	  <p><small>This is a resource to a variety of presentations describing the various platforms and software created at the McGill Centre for Intergrative Neurosciecne at the Montreal Neurological Institute.</small></p>
+	  <p><small>This is a resource to a variety of presentations describing the various platforms and software created at the McGill Centre for Integrative Neuroscience at the Montreal Neurological Institute.</small></p>
 
 	  
 	  <table class = "reveal">


### PR DESCRIPTION
Fixed two typos on the index page -> `Neuroscience` and `Integrative`